### PR TITLE
Require scons to pass

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -60,8 +60,8 @@ def pytest_sessionstart(session):
         raise RuntimeError('ftlib tests should be run from the root directory, and the current working directory seems wrong')
     # build once the binary we will run for every test
     fcsim_dir = root_dir / 'fcsim'
-    subprocess.run(['scons'])
-    subprocess.run(['scons'], cwd=fcsim_dir)
+    subprocess.check_call(['scons'])
+    subprocess.check_call(['scons'], cwd=fcsim_dir)
 
 def pytest_runtest_logreport(report):
     """


### PR DESCRIPTION
# Tests - Do not skip this

- [x] I ran the tests with `--all`
- [x] There are no regressions
- [x] If the pass rate changed, I also put my run result in `test/history/reference/`

# Motivation

- [x] I explained why I am making this PR

# New infrastructure or features

- [x] I explained what changes I am adding
- [x] My new features have tests

Tests now fail immediately if scons failed. This should make testing more robust in a dirty environment.

# Breaking API changes

- [x] I explained any part of the interface that was changed, deprecated, or removed