### PR TITLE
Add environment.sh to be nice to Python users

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -1,0 +1,2 @@
+export FTLIB_DIR="$(pwd)"
+export PYTHONPATH="${FTLIB_DIR}/test:${PYTHONPATH}"


### PR DESCRIPTION
# Tests - Do not skip this

- [ ] I ran the tests with `--all`
- [ ] There are no regressions
- [ ] If the pass rate changed, I also put my run result in `test/history/reference/`

No existing code changed. N/A

# Motivation

- [ ] I explained why I am making this PR

A lot of our utils are shoved in the `test/` directory, making them not easily accessible to outside users. As a developer of one such outside user application, I find myself hacking in a fix. Which we should have just done this way, the obvious way.

# New infrastructure or features

- [ ] I explained what changes I am adding
- [ ] My new features have tests

New `environment.sh` file that adds `test/` to your Python file so you can import `run_design` or whatever.

# Breaking API changes

- [ ] I explained any part of the interface that was changed, deprecated, or removed

N/A