### PR TITLE
Enable hardfloat in default build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,6 @@
 import os
 
-env = Environment(CXX='g++', CXXFLAGS='-std=c++17', CPPPATH=['src'], LIBS=[], LIBPATH=[])
+env = Environment(CXX='g++', CXXFLAGS='-std=c++17', CPPDEFINES=['HARDFLOAT_TOGGLE'], CPPPATH=['src'], LIBS=[], LIBPATH=[])
 
 env['godot'] = False  # Custom flag for shared SConscript logic
 


### PR DESCRIPTION
# Tests - Do not skip this

- [x] I ran the tests with `--all`
- [x] There are no regressions
- [x] If the pass rate changed, I also put my run result in `test/history/reference/`

# Motivation

- [x] I explained why I am making this PR

Hardfloat is in fact safe to use for basic arithmetic operations. Every modern CPU has it. It is required by IEEE 754.

# New infrastructure or features

- [x] I explained what changes I am adding
- [x] My new features have tests

Hardfloat is now toggled on by default. Tests finish in 1 minute on my PC, so about 7x speed up.

# Breaking API changes

- [x] I explained any part of the interface that was changed, deprecated, or removed